### PR TITLE
Add diffuse lighting

### DIFF
--- a/src/main.mojo
+++ b/src/main.mojo
@@ -49,7 +49,7 @@ fn main() raises:
     alias max_depth = 8
     alias max_samples = 1024 * 1024
     alias background_light = Color4[float_type](0.5, 0.7, 1.0, 1.0)
-    alias background_dark = Color4[float_type](0.05, 0.1, 0.15, 1.0)
+    alias background_dark = Color4[float_type](0.03, 0.06, 0.08, 1.0)
 
     # ECS
     var store = ComponentStore[float_type, 3]()

--- a/src/main.mojo
+++ b/src/main.mojo
@@ -48,6 +48,8 @@ fn main() raises:
     alias channels = 4
     alias max_depth = 8
     alias max_samples = 1024 * 1024
+    alias background_light = Color4[float_type](0.5, 0.7, 1.0, 1.0)
+    alias background_dark = Color4[float_type](0.05, 0.1, 0.15, 1.0)
 
     # ECS
     var store = ComponentStore[float_type, 3]()
@@ -65,6 +67,7 @@ fn main() raises:
         channels=channels,
         max_depth=max_depth,
         max_samples=max_samples,
+        background=background_dark
     ]()
 
     # Collect timing stats - TODO: Tidy and move

--- a/src/mo3d/material/dielectric.mojo
+++ b/src/mo3d/material/dielectric.mojo
@@ -51,6 +51,9 @@ struct Dielectric[T: DType, dim: Int](CollectionElement):
         r0 = r0 * r0
         return r0 + (1 - r0) * pow((1 - cosine), 5)
 
+    fn emission(self, rec : HitRecord[T,dim]) raises -> Color4[T]:
+        return Color4[T](0, 0, 0)
+
     fn __str__(self) -> String:
         return (
             "Dielectric(refraction_index: " + str(self.refraction_index) + ")"

--- a/src/mo3d/material/diffuse_light.mojo
+++ b/src/mo3d/material/diffuse_light.mojo
@@ -1,0 +1,24 @@
+from mo3d.math.vec import Vec
+from mo3d.ray.color4 import Color4
+from mo3d.ray.ray import Ray
+from mo3d.ray.hit_record import HitRecord
+
+
+@value
+struct DiffuseLight[T: DType, dim: Int](CollectionElement):
+    var emit: Color4[T]
+
+    fn scatter(
+        self,
+        r_in: Ray[T, dim],
+        rec: HitRecord[T, dim],
+        inout attenuation: Color4[T],
+        inout scattered: Ray[T, dim],
+    ) -> Bool:
+        return False
+
+    fn emission(self, rec : HitRecord[T,dim]) -> Color4[T]:
+        return self.emit
+
+    fn __str__(self) -> String:
+        return "Diffuse Light(emitting: " + str(self.emit) + ")"

--- a/src/mo3d/material/lambertian.mojo
+++ b/src/mo3d/material/lambertian.mojo
@@ -23,5 +23,8 @@ struct Lambertian[T: DType, dim: Int](CollectionElement):
         attenuation = self.albedo
         return True
 
+    fn emission(self, rec : HitRecord[T,dim]) -> Color4[T]:
+        return Color4[T](0, 0, 0)
+
     fn __str__(self) -> String:
         return "Lambertian(albedo: " + str(self.albedo) + ")"

--- a/src/mo3d/material/material.mojo
+++ b/src/mo3d/material/material.mojo
@@ -7,12 +7,13 @@ from mo3d.ray.hit_record import HitRecord
 from mo3d.material.lambertian import Lambertian
 from mo3d.material.metal import Metal
 from mo3d.material.dielectric import Dielectric
+from mo3d.material.diffuse_light import DiffuseLight
 
 
 @value
 struct Material[T: DType, dim: Int]:
     alias Variant = Variant[
-        Lambertian[T, dim], Metal[T, dim], Dielectric[T, dim]
+        Lambertian[T, dim], Metal[T, dim], Dielectric[T, dim], DiffuseLight[T, dim]
     ]
     var _mat: Self.Variant
 
@@ -36,6 +37,31 @@ struct Material[T: DType, dim: Int]:
         elif self._mat.isa[Dielectric[T, dim]]():
             return self._mat[Dielectric[T, dim]].scatter(
                 r_in, rec, attenuation, scattered
+            )
+        elif self._mat.isa[DiffuseLight[T, dim]]():
+            return self._mat[DiffuseLight[T, dim]].scatter(
+                r_in, rec, attenuation, scattered
+            )
+        raise Error("Material type not supported")
+
+    fn emission(self, rec : HitRecord[T,dim]) raises -> Color4[T]:
+        # TODO perform the runtime variant match
+        if self._mat.isa[Lambertian[T, dim]]():
+            return self._mat[Lambertian[T, dim]].emission(
+                rec
+            )
+        elif self._mat.isa[Metal[T, dim]]():
+            return self._mat[Metal[T, dim]].emission(
+                rec
+            )
+
+        elif self._mat.isa[Dielectric[T, dim]]():
+            return self._mat[Dielectric[T, dim]].emission(
+                rec
+            )
+        elif self._mat.isa[DiffuseLight[T, dim]]():
+            return self._mat[DiffuseLight[T, dim]].emission(
+                rec
             )
         raise Error("Material type not supported")
 

--- a/src/mo3d/material/metal.mojo
+++ b/src/mo3d/material/metal.mojo
@@ -24,6 +24,9 @@ struct Metal[T: DType, dim: Int](CollectionElement):
         attenuation = self.albedo
         return scattered.dir.dot(rec.normal) > 0.0
 
+    fn emission(self, rec : HitRecord[T,dim]) -> Color4[T]:
+        return Color4[T](0, 0, 0)
+
     fn __str__(self) -> String:
         return (
             "Metal(albedo: "

--- a/src/mo3d/sample/sphere_scene.mojo
+++ b/src/mo3d/sample/sphere_scene.mojo
@@ -99,8 +99,6 @@ fn sphere_scene_3d[T: DType](inout store: ComponentStore[T, 3], grid_size: Int =
                         Geometry[T, dim](sphere),
                         sphere_material,
                     )
-                    print("Light")
-    print("Here")
     # Big Spheres
     var mat1 = Material[T, dim](Dielectric[T, dim](1.5))
     var sphere1 = Sphere[T, dim](1.0)

--- a/src/mo3d/sample/sphere_scene.mojo
+++ b/src/mo3d/sample/sphere_scene.mojo
@@ -90,7 +90,7 @@ fn sphere_scene_3d[T: DType](inout store: ComponentStore[T, 3], grid_size: Int =
                     )
                 else:
                     # light
-                    sphere_material = Material[T, dim](DiffuseLight[T, dim](Color4[T](1,1,1,1)))
+                    sphere_material = Material[T, dim](DiffuseLight[T, dim](Color4[T](6.0,6.0,6.0,1)))
                     var sphere = Sphere[T, dim](0.2)
                     var sphere_entity_id = store.create_entity()
                     _ = store.add_components(

--- a/src/mo3d/sample/sphere_scene.mojo
+++ b/src/mo3d/sample/sphere_scene.mojo
@@ -10,6 +10,7 @@ from mo3d.material.material import Material
 from mo3d.material.lambertian import Lambertian
 from mo3d.material.metal import Metal
 from mo3d.material.dielectric import Dielectric
+from mo3d.material.diffuse_light import DiffuseLight
 
 
 fn sphere_scene_3d[T: DType](inout store: ComponentStore[T, 3], grid_size: Int = 11) raises:
@@ -47,7 +48,7 @@ fn sphere_scene_3d[T: DType](inout store: ComponentStore[T, 3], grid_size: Int =
             if (center - Point[T, dim](4, 0.2, 0)).length() > 0.9:
                 var sphere_material: Material[T, dim]
 
-                if choose_mat < 0.8:
+                if choose_mat < 0.7:
                     # diffuse
                     var albedo = Color4[T].random() * Color4[T].random()
                     sphere_material = Material[T, dim](
@@ -61,7 +62,7 @@ fn sphere_scene_3d[T: DType](inout store: ComponentStore[T, 3], grid_size: Int =
                         Geometry[T, dim](sphere),
                         sphere_material,
                     )
-                elif choose_mat < 0.95:
+                elif choose_mat < 0.8:
                     # metal
                     var albedo = Color4[T].random(0.5, 1)
                     var fuzz = random_float(0, 0.5)
@@ -76,7 +77,7 @@ fn sphere_scene_3d[T: DType](inout store: ComponentStore[T, 3], grid_size: Int =
                         Geometry[T, dim](sphere),
                         sphere_material,
                     )
-                else:
+                elif choose_mat < 0.9:
                     # glass
                     sphere_material = Material[T, dim](Dielectric[T, dim](1.5))
                     var sphere = Sphere[T, dim](0.2)
@@ -87,7 +88,19 @@ fn sphere_scene_3d[T: DType](inout store: ComponentStore[T, 3], grid_size: Int =
                         Geometry[T, dim](sphere),
                         sphere_material,
                     )
-
+                else:
+                    # light
+                    sphere_material = Material[T, dim](DiffuseLight[T, dim](Color4[T](1,1,1,1)))
+                    var sphere = Sphere[T, dim](0.2)
+                    var sphere_entity_id = store.create_entity()
+                    _ = store.add_components(
+                        sphere_entity_id,
+                        center,
+                        Geometry[T, dim](sphere),
+                        sphere_material,
+                    )
+                    print("Light")
+    print("Here")
     # Big Spheres
     var mat1 = Material[T, dim](Dielectric[T, dim](1.5))
     var sphere1 = Sphere[T, dim](1.0)


### PR DESCRIPTION
Following https://raytracing.github.io we add diffuse lighting via an emmisive property on materials.

We pass in the background colour to allow making the sample to test individual lights.

![image](https://github.com/user-attachments/assets/42b7422b-3751-483f-b216-dcd7718495f9)
