### PR TITLE
Split the BVH out of the scene graph

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -14,6 +14,7 @@ package = { cmd = "mkdir -p bin && magic run mojo package src/mo3d -o bin/mo3d.m
 test = { cmd = "magic run mojo test ./test", depends-on = ["package"], inputs=["src/**/*.mojo", "test/**/*.mojo"] }
 build = { cmd = "mkdir -p bin && magic run mojo build src/main.mojo -o bin/mo3d", depends-on = ["setup", "build-setup"], inputs=["src/**/*.mojo"], outputs = ["bin/mo3d"] }
 built = { cmd = "bin/mo3d", depends-on = ["build"] }
+perf = { cmd = "perf record -F 99 --call-graph bin/mo3d", depends-on = ["build"]  }
 
 [dependencies]
 max = ">=24.6.0.dev2024121016,<25"

--- a/src/main.mojo
+++ b/src/main.mojo
@@ -54,7 +54,7 @@ fn main() raises:
     var store = ComponentStore[float_type, 3]()
     # sphere_scene_3d[float_type](store, 150)
     sphere_scene_3d[float_type](store, 4)
-    var bvh_root_entity = construct_bvh(store)
+    var bvh_root = construct_bvh(store)
 
     # Camera
     var camera = Camera[
@@ -81,8 +81,7 @@ fn main() raises:
     while window.process_events(camera):
         start_time = perf_counter()
         camera.render(
-            store,
-            bvh_root_entity,
+            bvh_root,
             last_compute_time.cast[DType.int64]() * 10**3,
             last_redraw_time.cast[DType.int64]() * 10**6,
         )

--- a/src/mo3d/camera/camera.mojo
+++ b/src/mo3d/camera/camera.mojo
@@ -16,6 +16,8 @@ from mo3d.ray.ray import Ray
 from mo3d.ray.hit_record import HitRecord
 from mo3d.ray.hit_entity import hit_entity
 
+from mo3d.scene.construct_bvh import BVHNode
+
 from mo3d.ecs.entity import EntityID
 from mo3d.ecs.component import (
     ComponentID,
@@ -229,8 +231,7 @@ struct Camera[
 
     fn render(
         inout self,
-        store: ComponentStore[T, dim],
-        bvh_root_entity: EntityID,
+        bvh_root : BVHNode[T, dim],
         compute_time_ms: Int64,
         redraw_time_ns: Int64,
         num_samples: Int = 1,
@@ -258,8 +259,7 @@ struct Camera[
                     pixel_color += Self._ray_color(
                         r,
                         max_depth,
-                        store,
-                        bvh_root_entity,
+                        bvh_root,
                         self.background
                     )
                 pixel_color *= pixel_samples_scale.cast[T]()
@@ -368,8 +368,7 @@ struct Camera[
     fn _ray_color(
         r: Ray[T, dim],
         depth: Int,
-        store: ComponentStore[T, dim],
-        bvh_root_entity: EntityID,
+        bvh_root : BVHNode[T, dim],
         background : Color4[T]
     ) -> Color4[T]:
         """
@@ -381,7 +380,7 @@ struct Camera[
         # BVH traversal
         var ray_t = Interval[T](0.001, inf[T]())
         var rec = HitRecord[T, dim]()
-        var hit_anything = hit_entity(store, bvh_root_entity, r, ray_t, rec)
+        var hit_anything = hit_entity(bvh_root, r, ray_t, rec)
 
         # If we hit something, scatter the ray and recurse
         if hit_anything:
@@ -393,8 +392,7 @@ struct Camera[
                     return attenuation * Self._ray_color(
                         scattered,
                         depth - 1,
-                        store,
-                        bvh_root_entity,
+                        bvh_root,
                         background
                     ) + emitted
                 return emitted

--- a/src/mo3d/ecs/component.mojo
+++ b/src/mo3d/ecs/component.mojo
@@ -20,13 +20,6 @@ alias MaterialComponent = Material
 
 alias BoundingBoxComponent = AABB
 
-
-@value
-struct BinaryChildrenComponent:
-    var left: EntityID
-    var right: EntityID
-
-
 alias ComponentID = Int
 
 alias ComponentTypeID = Int
@@ -39,4 +32,3 @@ struct ComponentType:
     alias Geometry: ComponentTypeID = 1 << 3
     alias Material: ComponentTypeID = 1 << 4
     alias BoundingBox: ComponentTypeID = 1 << 5
-    alias BinaryChildren: ComponentTypeID = 1 << 6

--- a/src/mo3d/ecs/component_store.mojo
+++ b/src/mo3d/ecs/component_store.mojo
@@ -15,8 +15,7 @@ from mo3d.ecs.component import (
     OrientationComponent,
     GeometryComponent,
     MaterialComponent,
-    BoundingBoxComponent,
-    BinaryChildrenComponent,
+    BoundingBoxComponent
 )
 
 
@@ -36,8 +35,7 @@ struct ComponentStore[T: DType, dim: Int]:
         OrientationComponent[T, dim],
         GeometryComponent[T, dim],
         MaterialComponent[T, dim],
-        BoundingBoxComponent[T, dim],
-        BinaryChildrenComponent,
+        BoundingBoxComponent[T, dim]
     ]
 
     var position_components: List[PositionComponent[T, dim]]
@@ -57,9 +55,6 @@ struct ComponentStore[T: DType, dim: Int]:
 
     var bounding_box_components: List[BoundingBoxComponent[T, dim]]
     var bounding_box_component_to_entities: Dict[ComponentID, EntityID]
-
-    var binary_children_components: List[BinaryChildrenComponent]
-    var binary_children_component_to_entities: Dict[ComponentID, EntityID]
 
     var entity_to_components: Dict[EntityID, Dict[ComponentTypeID, ComponentID]]
     var entity_to_component_type_mask: Dict[EntityID, ComponentTypeID]
@@ -82,11 +77,6 @@ struct ComponentStore[T: DType, dim: Int]:
 
         self.bounding_box_components = List[BoundingBoxComponent[T, dim]]()
         self.bounding_box_component_to_entities = Dict[ComponentID, EntityID]()
-
-        self.binary_children_components = List[BinaryChildrenComponent]()
-        self.binary_children_component_to_entities = Dict[
-            ComponentID, EntityID
-        ]()
 
         self.entity_to_components = Dict[
             EntityID, Dict[ComponentTypeID, ComponentID]
@@ -194,28 +184,6 @@ struct ComponentStore[T: DType, dim: Int]:
 
         return component_id
 
-    fn _add_binary_children_component(
-        inout self, entity_id: EntityID, component: BinaryChildrenComponent
-    ) raises -> ComponentID:
-        if (
-            self.entity_to_component_type_mask[entity_id]
-            & ComponentType.BinaryChildren
-        ):
-            raise Error("Entity already has a binary children component")
-
-        self.binary_children_components.append(component)
-        var component_id = ComponentID(len(self.binary_children_components) - 1)
-        self.binary_children_component_to_entities[component_id] = entity_id
-
-        self.entity_to_components[entity_id][
-            ComponentType.BinaryChildren
-        ] = component_id
-        self.entity_to_component_type_mask[
-            entity_id
-        ] |= ComponentType.BinaryChildren
-
-        return component_id
-
     fn create_entity(inout self) -> EntityID:
         """
         This implementation is not thread safe.
@@ -256,10 +224,6 @@ struct ComponentStore[T: DType, dim: Int]:
         elif component.isa[BoundingBoxComponent[T, dim]]():
             return self._add_bounding_box_component(
                 entity_id, component[BoundingBoxComponent[T, dim]]
-            )
-        elif component.isa[BinaryChildrenComponent]():
-            return self._add_binary_children_component(
-                entity_id, component[BinaryChildrenComponent]
             )
         else:
             raise Error("Unknown component type")

--- a/src/mo3d/ray/hit_entity.mojo
+++ b/src/mo3d/ray/hit_entity.mojo
@@ -42,7 +42,7 @@ fn hit_bvh[
     inout rec: HitRecord[T, dim],
 ) -> Bool:
     """
-    Hit a ray again a split bvh node
+    Hit a ray again a split bvh node.
     """
     rec.hits += 1
 
@@ -65,7 +65,7 @@ fn hit_hittable[
     inout rec: HitRecord[T, dim],
 ) -> Bool:
     """
-    Hit a ray against hitable geometry / material pair
+    Hit a ray against hitable geometry / material pair.
     """
     var hit = hittable.geometry.hit(r, ray_t, rec, hittable.position, hittable.material)
     if hit:

--- a/src/mo3d/ray/hit_entity.mojo
+++ b/src/mo3d/ray/hit_entity.mojo
@@ -6,15 +6,14 @@ from mo3d.material.material import Material
 from mo3d.material.lambertian import Lambertian
 from mo3d.material.metal import Metal
 from mo3d.ecs.entity import EntityID
-from mo3d.ecs.component import ComponentType, BinaryChildrenComponent
+from mo3d.ecs.component import ComponentType
 from mo3d.ecs.component_store import ComponentStore
-
+from mo3d.scene.construct_bvh import BVHNode, BVHSplit, Hittable
 
 fn hit_entity[
     T: DType, dim: Int
 ](
-    store: ComponentStore[T, dim],
-    entity: EntityID,
+    bvh_node : BVHNode[T, dim],
     r: Ray[T, dim],
     owned ray_t: Interval[T],
     inout rec: HitRecord[T, dim],
@@ -22,97 +21,53 @@ fn hit_entity[
     """
     ECS 'system' to intersect a ray with an entity in the component store.
     """
+    if not bvh_node.box.hit(r, ray_t):
+        return False
     # Is the entity a BVH or Leaf Geometry?
-    if store.entity_has_components(
-        entity, ComponentType.BoundingBox | ComponentType.BinaryChildren
-    ):
-        return hit_bvh(store, entity, r, ray_t, rec)
-    elif store.entity_has_components(
-        entity,
-        ComponentType.Position
-        | ComponentType.Geometry
-        | ComponentType.Material,
-    ):
-        return hit_geometry(store, entity, r, ray_t, rec)
+    if bvh_node._wrapped.isa[BVHSplit[T, dim]]():
+        return hit_bvh(bvh_node._wrapped[BVHSplit[T, dim]], r, ray_t, rec)
+    elif bvh_node._wrapped.isa[Hittable[T, dim]]():
+        return hit_hittable(bvh_node._wrapped[Hittable[T, dim]], r, ray_t, rec)
     else:
-        print("Entity is unhitable", entity)
+        print("bvh_node is unhitable")
         return False
 
 
 fn hit_bvh[
     T: DType, dim: Int
 ](
-    store: ComponentStore[T, dim],
-    bvh_entity: EntityID,
+    bvh : BVHSplit[T, dim],
     r: Ray[T, dim],
     owned ray_t: Interval[T],
     inout rec: HitRecord[T, dim],
 ) -> Bool:
     """
-    ECS 'system' to intersect a ray with a bvh entity in the component store.
+    Hit a ray again a split bvh node
     """
-    try:
-        var bbox_comp_id = store.entity_to_components[bvh_entity][
-            ComponentType.BoundingBox
-        ]
-        var bbox = store.bounding_box_components[bbox_comp_id]
+    rec.hits += 1
 
-        if not bbox.hit(r, ray_t):
-            return False
-        rec.hits += 1
-
-        var binary_children_comp_id = store.entity_to_components[bvh_entity][
-            ComponentType.BinaryChildren
-        ]
-        var binary_children = store.binary_children_components[
-            binary_children_comp_id
-        ]
-
-        var hit_left = hit_entity(store, binary_children.left, r, ray_t, rec)
-        var hit_right = hit_entity(
-            store,
-            binary_children.right,
-            r,
-            Interval(ray_t.min, rec.t if hit_left else ray_t.max), # If hit on left, limit right ray_t max to hit point on left
-            rec,
-        )
-        return hit_left or hit_right
-    except:
-        print("Error in hit_bvh")
-        return False
+    var hit_left = hit_entity(bvh.left[], r, ray_t, rec)
+    var hit_right = hit_entity(
+        bvh.right[],
+        r,
+        Interval(ray_t.min, rec.t if hit_left else ray_t.max), # If hit on left, limit right ray_t max to hit point on left
+        rec,
+    )
+    return hit_left or hit_right
 
 
-fn hit_geometry[
+fn hit_hittable[
     T: DType, dim: Int
 ](
-    store: ComponentStore[T, dim],
-    geometry_entity: EntityID,
+    hittable : Hittable[T, dim],
     r: Ray[T, dim],
     owned ray_t: Interval[T],
     inout rec: HitRecord[T, dim],
 ) -> Bool:
     """
-    ECS 'system' to intersect a ray with a geometric entity in the component store.
-    The component must have geometry, position and material components.
+    Hit a ray against hitable geometry / material pair
     """
-    try:
-        var position_comp_id = store.entity_to_components[geometry_entity][
-            ComponentType.Position
-        ]
-        var position = store.position_components[position_comp_id]
-        var geometry_comp_id = store.entity_to_components[geometry_entity][
-            ComponentType.Geometry
-        ]
-        var geometry = store.geometry_components[geometry_comp_id]
-        var material_comp_id = store.entity_to_components[geometry_entity][
-            ComponentType.Material
-        ]
-        var material = store.material_components[material_comp_id]
-
-        var hit = geometry.hit(r, ray_t, rec, position, material)
-        if hit:
-            rec.hits += 1
-        return hit
-    except:
-        print("Error in hit_geometry")
-        return False
+    var hit = hittable.geometry.hit(r, ray_t, rec, hittable.position, hittable.material)
+    if hit:
+        rec.hits += 1
+    return hit

--- a/src/mo3d/scene/construct_bvh.mojo
+++ b/src/mo3d/scene/construct_bvh.mojo
@@ -1,20 +1,46 @@
-from memory import UnsafePointer
+from memory.arc import ArcPointer
+from utils import Variant
+from collections import InlineArray
 
 from mo3d.geometry.aabb import AABB
 from mo3d.ecs.entity import EntityID
-from mo3d.ecs.component import ComponentType, BinaryChildrenComponent
+from mo3d.ecs.component import ComponentType
 from mo3d.ecs.component_store import ComponentStore
+
+from mo3d.geometry.geometry import Geometry
+from mo3d.material.material import Material
+
+from mo3d.math.point import Point
+
+@value 
+struct Hittable[T : DType, dim : Int]:
+    var geometry : Geometry[T, dim]
+    var material : Material[T, dim]
+    var position : Point[T, dim]
+
+@value
+struct BVHSplit[T: DType, dim: Int]:
+    var left : ArcPointer[BVHNode[T, dim]]
+    var right : ArcPointer[BVHNode[T, dim]]
+
+@value
+struct BVHNode[T: DType, dim: Int]:
+    alias Variant = Variant[
+        BVHSplit[T, dim], 
+        Hittable[T, dim]]
+    var _wrapped: Self.Variant
+    var box : AABB[T, dim]
+
 
 
 fn build_bvh_nodes_recursive[
     T: DType, dim: Int
 ](
-    entity: EntityID,
-    inout store: ComponentStore[T, dim],
-    entities: UnsafePointer[List[EntityID]],
+    store: ComponentStore[T, dim],
+    mut entities: List[EntityID],
     start: Int,
     end: Int,
-) raises:
+) raises -> BVHNode[T, dim]:
     """
     Construct a BVH node from a list of entities.
     """
@@ -27,7 +53,7 @@ fn build_bvh_nodes_recursive[
     # Build the bounding box of the span of source objects.
     var bbox = AABB[T, dim]()
     for i in range(start, end):
-        var entity = entities[][i]
+        var entity = entities[i]
         var entity_position = store.position_components[
             store.entity_to_components[entity][ComponentType.Position]
         ]
@@ -36,9 +62,6 @@ fn build_bvh_nodes_recursive[
         ]
         var entity_aabb = entity_geometry.aabb()
         bbox = AABB[T, dim](bbox, entity_aabb + entity_position)
-
-    # Update the bounding box of this new BVH node
-    _ = store.add_component(entity, bbox)
 
     var axis = bbox.longest_axis()
     var span = end - start
@@ -56,18 +79,18 @@ fn build_bvh_nodes_recursive[
 
     if span == 1:
         # Leaf node, add a bvh wrapper around the entity
-        var entity_binary_children = BinaryChildrenComponent(
-            entities[][start], entities[][start]
-        )
-        _ = store.add_component(entity, entity_binary_children)
-        return
-    elif span == 2:
-        # Leaf node, add a bvh wrapper around the entities
-        var entity_binary_children = BinaryChildrenComponent(
-            entities[][start], entities[][start + 1]
-        )
-        _ = store.add_component(entity, entity_binary_children)
-        return
+        var entity_geometry = store.geometry_components[
+            store.entity_to_components[start][ComponentType.Geometry]
+        ]
+        var entity_material = store.material_components[
+            store.entity_to_components[start][ComponentType.Material]
+        ]
+        var entity_position = store.position_components[
+            store.entity_to_components[start][ComponentType.Position]
+        ]
+        return BVHNode[T, dim](
+            Hittable(entity_geometry, entity_material, entity_position), 
+            bbox)
     else:
         # Sort to entities along the longest axis
         @parameter
@@ -84,7 +107,7 @@ fn build_bvh_nodes_recursive[
                 return False
 
         # Sort the entities along the longest axis within this span
-        var slice = entities[][start:end]
+        var slice = entities[start:end]
         sort[cmp](slice)
 
         # Prevent parametric cleanup...
@@ -92,26 +115,22 @@ fn build_bvh_nodes_recursive[
 
         var mid = start + span // 2
 
-        # Create left and right child nodes
-        var left_child = store.create_entity()
-        var right_child = store.create_entity()
-        var entity_binary_children = BinaryChildrenComponent(
-            left_child, right_child
-        )
-        _ = store.add_component(entity, entity_binary_children)
-
         # Recursively build the left and right child nodes
-        build_bvh_nodes_recursive[T, dim](
-            left_child, store, entities, start, mid
+        var left_child = build_bvh_nodes_recursive[T, dim](
+            store, entities, start, mid
         )
-        build_bvh_nodes_recursive[T, dim](
-            right_child, store, entities, mid, end
+        var right_child = build_bvh_nodes_recursive[T, dim](
+            store, entities, mid, end
+        )
+        return BVHNode[T, dim](
+            BVHSplit[T, dim](left_child, right_child),
+            bbox
         )
 
 
 fn construct_bvh[
     T: DType, dim: Int
-](inout store: ComponentStore[T, dim]) raises -> EntityID:
+](store: ComponentStore[T, dim]) raises -> BVHNode[T, dim]:
     """
     ECS 'system' to construct a BVH from all components in store with position and geometry.
     Returns the root entity ID of the BVH.
@@ -122,15 +141,11 @@ fn construct_bvh[
         ComponentType.Position | ComponentType.Geometry
     )
 
-    var root = store.create_entity()
-    build_bvh_nodes_recursive[T, dim](
-        root,
+    var root = build_bvh_nodes_recursive[T, dim](
         store,
-        UnsafePointer[List[EntityID]].address_of(entities),
+        entities,
         0,
         len(entities),
     )
-    _ = entities
-    print("Constructed BVH! Root entity id:", root)
-
+    print("Constructed BVH!")
     return root

--- a/src/mo3d/scene/construct_bvh.mojo
+++ b/src/mo3d/scene/construct_bvh.mojo
@@ -31,6 +31,18 @@ struct BVHNode[T: DType, dim: Int]:
     var _wrapped: Self.Variant
     var box : AABB[T, dim]
 
+    fn count_hittables(self) -> Int:
+        if self._wrapped.isa[BVHSplit[T, dim]]():
+            return self._wrapped[BVHSplit[T, dim]].left[].count_hittables() +  self._wrapped[BVHSplit[T, dim]].right[].count_hittables()
+        else:
+            return 1
+
+    fn count_nodes(self) -> Int:
+        if self._wrapped.isa[BVHSplit[T, dim]]():
+            return 1 + self._wrapped[BVHSplit[T, dim]].left[].count_hittables() +  self._wrapped[BVHSplit[T, dim]].right[].count_hittables()
+        else:
+            return 0
+
 
 
 fn build_bvh_nodes_recursive[

--- a/test/mo3d/test_ecs.mojo
+++ b/test/mo3d/test_ecs.mojo
@@ -11,7 +11,7 @@ alias f32 = DType.float32
 
 
 fn test_create_empty_component_store() raises:
-    var store = ComponentStore[f32, 3]()
+    var _store = ComponentStore[f32, 3]()
 
 
 fn test_add_entity_to_component_store() raises:

--- a/test/mo3d/test_ecs.mojo
+++ b/test/mo3d/test_ecs.mojo
@@ -5,7 +5,7 @@ from mo3d.geometry.geometry import Geometry
 from mo3d.geometry.sphere import Sphere
 
 from mo3d.ecs.component_store import ComponentStore
-from mo3d.ecs.component import ComponentID, ComponentTypeID, ComponentType, BinaryChildrenComponent
+from mo3d.ecs.component import ComponentID, ComponentTypeID, ComponentType
 
 alias f32 = DType.float32
 
@@ -85,15 +85,3 @@ fn test_add_bvh_entity_to_component_store() raises:
     assert_almost_equal(bvh._bounds[2].min, -1.0)
     assert_almost_equal(bvh._bounds[2].max, 1.0)
 
-fn test_add_entity_with_children_to_component_store() raises:
-    var store = ComponentStore[f32, 3]()
-    var parent_entity = store.create_entity()
-    var child1_entity = store.create_entity()
-    var child2_entity = store.create_entity()
-
-    var binary_children_component = BinaryChildrenComponent(child1_entity, child2_entity)
-    _ = store.add_component(parent_entity, binary_children_component)
-
-    var query = store.get_entities_with_components(ComponentType.BinaryChildren)
-    assert_equal(len(query), 1)
-    assert_equal(query[0], parent_entity)

--- a/test/mo3d/test_ray.mojo
+++ b/test/mo3d/test_ray.mojo
@@ -46,7 +46,6 @@ fn test_miss_entity() raises:
     var store = ComponentStore[f32, 3]()
     basic_three_sphere_scene_3d(store)
     assert_equal(len(store.entity_to_components), 4)
-    var root_entity = construct_bvh(store)
     var bvh = construct_bvh(store)
 
     var r = Ray[DType.float32, 3](

--- a/test/mo3d/test_ray.mojo
+++ b/test/mo3d/test_ray.mojo
@@ -30,15 +30,14 @@ fn test_hit_entity() raises:
     var store = ComponentStore[f32, 3]()
     basic_three_sphere_scene_3d(store)
     assert_equal(len(store.entity_to_components), 4)
-    var root_entity = construct_bvh(store)
-    assert_equal(root_entity, 4)
+    var bvh = construct_bvh(store)
 
     var r = Ray[DType.float32, 3](
         Point[f32, 3](0.0, 1.0, 5.0), Vec[f32, 3](0.0, 0.0, -1.0)
     )
     var rec = HitRecord[f32, 3]()
     var ray_t = Interval[f32](-10, 10)
-    var hit = hit_entity(store, root_entity, r, ray_t, rec)
+    var hit = hit_entity(bvh, r, ray_t, rec)
     assert_equal(hit, True)
     assert_true(rec.hits > 0)
 
@@ -48,14 +47,14 @@ fn test_miss_entity() raises:
     basic_three_sphere_scene_3d(store)
     assert_equal(len(store.entity_to_components), 4)
     var root_entity = construct_bvh(store)
-    assert_equal(root_entity, 4)
+    var bvh = construct_bvh(store)
 
     var r = Ray[DType.float32, 3](
         Point[f32, 3](20.0, 20.0, 5.0), Vec[f32, 3](0.0, 0.0, -1.0)
     )
     var rec = HitRecord[f32, 3]()
     var ray_t = Interval[f32](0.001, inf[f32]())
-    var hit = hit_entity(store, root_entity, r, ray_t, rec)
+    var hit = hit_entity(bvh, r, ray_t, rec)
     assert_equal(hit, False)
     assert_equal(rec.hits, 0)
 
@@ -64,7 +63,7 @@ fn test_hit_entity_default_sphere_scene() raises:
     var store = ComponentStore[f32, 3]()
     sphere_scene_3d(store)
     var size = len(store.entity_to_components)
-    var root_entity = construct_bvh(store)
+    var bvh = construct_bvh(store)
 
     # Shoot a ray down from above the scene at the center
     var r = Ray[DType.float32, 3](
@@ -72,7 +71,7 @@ fn test_hit_entity_default_sphere_scene() raises:
     )
     var rec = HitRecord[f32, 3]()
     var ray_t = Interval[f32](0.001, inf[f32]())
-    var hit = hit_entity(store, root_entity, r, ray_t, rec)
+    var hit = hit_entity(bvh, r, ray_t, rec)
     assert_equal(hit, True)
     assert_true(Scalar[f32](rec.hits) < 5*log2(Scalar[f32](size)))
 
@@ -80,7 +79,7 @@ fn test_hit_entity_50_range_sphere_scene() raises:
     var store = ComponentStore[f32, 3]()
     sphere_scene_3d(store, 50)
     var size = len(store.entity_to_components)
-    var root_entity = construct_bvh(store)
+    var bvh = construct_bvh(store)
 
     # Shoot a ray down from above the scene at the center
     var r = Ray[DType.float32, 3](
@@ -88,6 +87,6 @@ fn test_hit_entity_50_range_sphere_scene() raises:
     )
     var rec = HitRecord[f32, 3]()
     var ray_t = Interval[f32](0.001, inf[f32]())
-    var hit = hit_entity(store, root_entity, r, ray_t, rec)
+    var hit = hit_entity(bvh, r, ray_t, rec)
     assert_equal(hit, True)
     assert_true(Scalar[f32](rec.hits) < 5*log2(Scalar[f32](size)))

--- a/test/mo3d/test_scene.mojo
+++ b/test/mo3d/test_scene.mojo
@@ -13,30 +13,7 @@ fn test_construct_bvh() raises:
     basic_three_sphere_scene_3d(store)
     assert_equal(len(store.entity_to_components), 4)
 
-    var root_entity = construct_bvh(store)
-    assert_equal(root_entity, 4)
+    var bvh = construct_bvh(store)
 
-    assert_true(
-        store.entity_has_components(root_entity, ComponentType.BinaryChildren)
-    )
-    var root_binary_children = store.binary_children_components[
-        store.entity_to_components[root_entity][ComponentType.BinaryChildren]
-    ]
-    assert_equal(root_binary_children.left, 5)
-    assert_equal(root_binary_children.right, 6)
-
-    var left_binary_children = store.binary_children_components[
-        store.entity_to_components[root_binary_children.left][
-            ComponentType.BinaryChildren
-        ]
-    ]
-    assert_equal(left_binary_children.left, 0)
-    assert_equal(left_binary_children.right, 1)
-
-    var right_binary_children = store.binary_children_components[
-        store.entity_to_components[root_binary_children.right][
-            ComponentType.BinaryChildren
-        ]
-    ]
-    assert_equal(right_binary_children.left, 2)
-    assert_equal(right_binary_children.right, 3)
+    assert_equal(bvh.count_hittables(), 4)
+    assert_equal(bvh.count_nodes(), 5)


### PR DESCRIPTION
With some quick perf running I found a big chunk of the render time is spend getting the bvh components out of the store.

I would like to have a go at improving that. My idea is to build the BVH from the ecs (on the CPU) that is then passed to the camera (the store not being passed).

This would be the way that a number of other systems go and has the advantage of avoiding any issues from the mutable store and Helping us as we hopefully move to make the data GPU renderable.

A quick check on the default scene reduced the time from 2600 ms to 200 ms per render pass.

Perf command added to magic to make perf timing easier