### PR TITLE
Improve performance with a custom RNG

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -14,7 +14,7 @@ package = { cmd = "mkdir -p bin && magic run mojo package src/mo3d -o bin/mo3d.m
 test = { cmd = "magic run mojo test ./test", depends-on = ["package"], inputs=["src/**/*.mojo", "test/**/*.mojo"] }
 build = { cmd = "mkdir -p bin && magic run mojo build src/main.mojo -o bin/mo3d", depends-on = ["setup", "build-setup"], inputs=["src/**/*.mojo"], outputs = ["bin/mo3d"] }
 built = { cmd = "bin/mo3d", depends-on = ["build"] }
-perf = { cmd = "perf record -F 99 --call-graph bin/mo3d", depends-on = ["build"]  }
+perf = { cmd = "perf record -F 99 --call-graph dwarf bin/mo3d", depends-on = ["build"]  }
 
 [dependencies]
 max = ">=24.6.0.dev2024121016,<25"

--- a/src/main.mojo
+++ b/src/main.mojo
@@ -3,7 +3,6 @@ from complex import ComplexSIMD, ComplexFloat64
 from math import iota, inf
 from memory import UnsafePointer, bitcast
 from pathlib import Path
-from random import random_float64
 from sys import simdwidthof
 from testing import assert_equal
 from time import sleep, perf_counter

--- a/src/mo3d/camera/camera.mojo
+++ b/src/mo3d/camera/camera.mojo
@@ -2,7 +2,6 @@ from algorithm import parallelize, vectorize
 from math import inf, iota, pi
 from math.math import tan
 from memory import UnsafePointer
-from random import random_float64
 
 from max.tensor import Tensor
 
@@ -17,6 +16,8 @@ from mo3d.ray.hit_record import HitRecord
 from mo3d.ray.hit_entity import hit_entity
 
 from mo3d.scene.construct_bvh import BVHNode
+
+from mo3d.random.rng import Rng
 
 from mo3d.ecs.entity import EntityID
 from mo3d.ecs.component import (
@@ -252,11 +253,13 @@ struct Camera[
             @parameter
             fn compute_row_vectorize[simd_width: Int](x: Int):
                 # Send a ray into the scene from this x, y coordinate
+                var rng = Rng(self._sensor_samples + (x << 24) + (y << 48))
                 var pixel_samples_scale = 1.0 / Scalar[T](num_samples)
                 var pixel_color = Color4[T](0, 0, 0, 0)
                 for _ in range(num_samples):
-                    var r = self.get_ray(x, y)
+                    var r = self.get_ray(rng, x, y)
                     pixel_color += Self._ray_color(
+                        rng,
                         r,
                         max_depth,
                         bvh_root,
@@ -328,35 +331,35 @@ struct Camera[
             "average redraw: " + str(redraw_time_ns) + " ns",
         )
 
-    fn get_ray(self, i: Int, j: Int) -> Ray[T, dim]:
-        var offset = Self._sample_square()
+    fn get_ray(self, mut rng : Rng, i: Int, j: Int) -> Ray[T, dim]:
+        var offset = Self._sample_square(rng)
 
         var pixel_sample = self._pixel00_loc + (
             (Scalar[T](i) + offset[0]) * self._pixel_delta_u
         ) + ((Scalar[T](j) + offset[1]) * self._pixel_delta_v)
 
-        var ray_origin = self._look_from if aperature <= 0.0 else self._defocus_disk_sample()
+        var ray_origin = self._look_from if aperature <= 0.0 else self._defocus_disk_sample(rng)
         var ray_direction = pixel_sample - ray_origin
-        var ray_time = random_float64().cast[T]()
+        var ray_time = rng.float64().cast[T]()
 
         return Ray(ray_origin, ray_direction, ray_time)
 
     @staticmethod
-    fn _sample_square() -> Vec[T, dim]:
+    fn _sample_square(mut rng : Rng) -> Vec[T, dim]:
         """
         Returns the vector to a random point in the [-.5,-.5]-[+.5,+.5] unit square.
         """
         return Vec[T, dim](
-            random_float64().cast[T]() - 0.5,
-            random_float64().cast[T]() - 0.5,
+            rng.float64().cast[T]() - 0.5,
+            rng.float64().cast[T]() - 0.5,
             0.0,
         )
 
-    fn _defocus_disk_sample(self) -> Point[T, dim]:
+    fn _defocus_disk_sample(self, mut rng : Rng) -> Point[T, dim]:
         """
         Returns a random point in the unit disk.
         """
-        var p = Vec[T, dim].random_in_unit_disk()
+        var p = Vec[T, dim].random_in_unit_disk(rng)
         return (
             self._look_from
             + self._defocus_disk_u * p[0]
@@ -366,6 +369,7 @@ struct Camera[
     @staticmethod
     @parameter
     fn _ray_color(
+        mut rng : Rng,
         r: Ray[T, dim],
         depth: Int,
         bvh_root : BVHNode[T, dim],
@@ -388,8 +392,9 @@ struct Camera[
             var attenuation = Color4[T]()
             try:
                 emitted = rec.mat.emission(rec)
-                if rec.mat.scatter(r, rec, attenuation, scattered):
+                if rec.mat.scatter(rng, r, rec, attenuation, scattered):
                     return attenuation * Self._ray_color(
+                        rng,
                         scattered,
                         depth - 1,
                         bvh_root,

--- a/src/mo3d/material/dielectric.mojo
+++ b/src/mo3d/material/dielectric.mojo
@@ -1,5 +1,4 @@
 from math import sqrt
-from random import random_float64
 
 from mo3d.math.vec import Vec
 from mo3d.ray.color4 import Color4
@@ -35,7 +34,7 @@ struct Dielectric[T: DType, dim: Int](CollectionElement):
 
         if (
             cannot_refract
-            or Self.reflectance(cos_theta, ri) > random_float64().cast[T]()
+            or Self.reflectance(cos_theta, ri) > rng.float64().cast[T]()
         ):
             direction = Vec[T, dim].reflect(unit_direction, rec.normal)
         else:

--- a/src/mo3d/material/dielectric.mojo
+++ b/src/mo3d/material/dielectric.mojo
@@ -6,6 +6,7 @@ from mo3d.ray.color4 import Color4
 from mo3d.ray.ray import Ray
 from mo3d.ray.hit_record import HitRecord
 
+from mo3d.random.rng import Rng
 
 @value
 struct Dielectric[T: DType, dim: Int](CollectionElement):
@@ -13,6 +14,7 @@ struct Dielectric[T: DType, dim: Int](CollectionElement):
 
     fn scatter(
         self,
+        mut rng : Rng,
         r_in: Ray[T, dim],
         rec: HitRecord[T, dim],
         inout attenuation: Color4[T],

--- a/src/mo3d/material/diffuse_light.mojo
+++ b/src/mo3d/material/diffuse_light.mojo
@@ -3,6 +3,7 @@ from mo3d.ray.color4 import Color4
 from mo3d.ray.ray import Ray
 from mo3d.ray.hit_record import HitRecord
 
+from mo3d.random.rng import Rng
 
 @value
 struct DiffuseLight[T: DType, dim: Int](CollectionElement):
@@ -10,6 +11,7 @@ struct DiffuseLight[T: DType, dim: Int](CollectionElement):
 
     fn scatter(
         self,
+        mut rng : Rng,
         r_in: Ray[T, dim],
         rec: HitRecord[T, dim],
         inout attenuation: Color4[T],

--- a/src/mo3d/material/lambertian.mojo
+++ b/src/mo3d/material/lambertian.mojo
@@ -6,18 +6,21 @@ from mo3d.ray.hit_record import HitRecord
 from mo3d.texture.texture import Texture
 from mo3d.texture.solid import Solid
 
+from mo3d.random.rng import Rng
+
 @value
 struct Lambertian[T: DType, dim: Int](CollectionElement):
     var albedo: Texture[T, dim]
 
     fn scatter(
         self,
+        mut rng : Rng,
         r_in: Ray[T, dim],
         rec: HitRecord[T, dim],
         inout attenuation: Color4[T],
         inout scattered: Ray[T, dim],
     ) raises -> Bool:
-        var scatter_direction = rec.normal + Vec[T, dim].random_unit_vector()
+        var scatter_direction = rec.normal + Vec[T, dim].random_unit_vector(rng)
         # Catch degenerate scatter direction
         if scatter_direction.near_zero():
             scatter_direction = rec.normal

--- a/src/mo3d/material/material.mojo
+++ b/src/mo3d/material/material.mojo
@@ -9,6 +9,7 @@ from mo3d.material.metal import Metal
 from mo3d.material.dielectric import Dielectric
 from mo3d.material.diffuse_light import DiffuseLight
 
+from mo3d.random.rng import Rng
 
 @value
 struct Material[T: DType, dim: Int]:
@@ -19,6 +20,7 @@ struct Material[T: DType, dim: Int]:
 
     fn scatter(
         self,
+        mut rng : Rng,
         r_in: Ray[T, dim],
         rec: HitRecord[T, dim],
         inout attenuation: Color4[T],
@@ -27,19 +29,19 @@ struct Material[T: DType, dim: Int]:
         # TODO perform the runtime variant match
         if self._mat.isa[Lambertian[T, dim]]():
             return self._mat[Lambertian[T, dim]].scatter(
-                r_in, rec, attenuation, scattered
+                rng, r_in, rec, attenuation, scattered
             )
         elif self._mat.isa[Metal[T, dim]]():
             return self._mat[Metal[T, dim]].scatter(
-                r_in, rec, attenuation, scattered
+                rng, r_in, rec, attenuation, scattered
             )
         elif self._mat.isa[Dielectric[T, dim]]():
             return self._mat[Dielectric[T, dim]].scatter(
-                r_in, rec, attenuation, scattered
+                rng, r_in, rec, attenuation, scattered
             )
         elif self._mat.isa[DiffuseLight[T, dim]]():
             return self._mat[DiffuseLight[T, dim]].scatter(
-                r_in, rec, attenuation, scattered
+                rng, r_in, rec, attenuation, scattered
             )
         raise Error("Material type not supported")
 

--- a/src/mo3d/material/metal.mojo
+++ b/src/mo3d/material/metal.mojo
@@ -3,6 +3,7 @@ from mo3d.ray.color4 import Color4
 from mo3d.ray.ray import Ray
 from mo3d.ray.hit_record import HitRecord
 
+from mo3d.random.rng import Rng
 
 @value
 struct Metal[T: DType, dim: Int](CollectionElement):
@@ -11,6 +12,7 @@ struct Metal[T: DType, dim: Int](CollectionElement):
 
     fn scatter(
         self,
+        mut rng : Rng,
         r_in: Ray[T, dim],
         rec: HitRecord[T, dim],
         inout attenuation: Color4[T],
@@ -18,7 +20,7 @@ struct Metal[T: DType, dim: Int](CollectionElement):
     ) -> Bool:
         var reflected = Vec[T, dim].reflect(r_in.dir, rec.normal)
         reflected = reflected.unit() + (
-            self.fuzz * Vec[T, dim].random_unit_vector()
+            self.fuzz * Vec[T, dim].random_unit_vector(rng)
         )
         scattered = Ray[T, dim](rec.p, reflected, r_in.tm)
         attenuation = self.albedo

--- a/src/mo3d/math/mat.mojo
+++ b/src/mo3d/math/mat.mojo
@@ -1,6 +1,5 @@
 from collections import InlineArray
 from math.math import cos, sin
-from random import random_float64
 
 from mo3d.math.vec import Vec
 

--- a/src/mo3d/math/vec.mojo
+++ b/src/mo3d/math/vec.mojo
@@ -1,7 +1,8 @@
 from algorithm import parallelize
 from collections import InlineArray
 from math import sqrt
-from random import random_float64
+
+from mo3d.random.rng import Rng
 
 
 struct Vec[T: DType, size: Int](EqualityComparable, Stringable):
@@ -83,27 +84,27 @@ struct Vec[T: DType, size: Int](EqualityComparable, Stringable):
         return self / self.length()
 
     @staticmethod
-    fn random_in_unit_disk() -> Self:
+    fn random_in_unit_disk(mut rng : Rng) -> Self:
         while True:
-            var p = Self.random(-1, 1)
+            var p = Self.random(rng, -1, 1)
             p[2] = 0
             if p.length_squared() < 1:
                 return p
 
     @staticmethod
-    fn random_in_unit_sphere() -> Self:
+    fn random_in_unit_sphere(mut rng : Rng) -> Self:
         while True:
-            var p = Self.random(-1, 1)
+            var p = Self.random(rng, -1, 1)
             if p.length_squared() < 1:
                 return p
 
     @staticmethod
-    fn random_unit_vector() -> Self:
-        return Self.random_in_unit_sphere().unit()
+    fn random_unit_vector(mut rng : Rng) -> Self:
+        return Self.random_in_unit_sphere(rng).unit()
 
     @staticmethod
-    fn random_on_hemisphere(normal: Self) -> Self:
-        var on_unit_sphere = Self.random_unit_vector()
+    fn random_on_hemisphere(mut rng : Rng, normal: Self) -> Self:
+        var on_unit_sphere = Self.random_unit_vector(rng)
         if on_unit_sphere.dot(normal) > 0:
             # In the same hemisphere as the normal
             return on_unit_sphere
@@ -122,19 +123,26 @@ struct Vec[T: DType, size: Int](EqualityComparable, Stringable):
         return r_out_perp + r_out_parallel
 
     @staticmethod
-    fn random() -> Self:
+    fn random(mut rng : Rng) -> Self:
         var data = InlineArray[Scalar[T], size](unsafe_uninitialized=True)
         for i in range(size):
-            data[i] = random_float64().cast[T]()
+            @parameter
+            if T == T.float64:
+                data[i] = rng.float64().cast[T]()
+            else:
+                data[i] = rng.float32().cast[T]()
         return Self(data)
 
     @staticmethod
-    fn random(min: Scalar[T], max: Scalar[T]) -> Self:
-        var min_64 = min.cast[DType.float64]()
-        var max_64 = max.cast[DType.float64]()
+    fn random(mut rng : Rng, min: Scalar[T], max: Scalar[T]) -> Self:
+        var delta = max - min
         var data = InlineArray[Scalar[T], size](unsafe_uninitialized=True)
         for i in range(size):
-            data[i] = random_float64(min_64, max_64).cast[T]()
+            @parameter
+            if T == T.float64:
+                data[i] = min + (rng.float64().cast[T]() * delta)
+            else:
+                data[i] = min + (rng.float32().cast[T]() * delta)
         return Self(data)
 
     fn __str__(self) -> String:

--- a/src/mo3d/random/rng.mojo
+++ b/src/mo3d/random/rng.mojo
@@ -1,0 +1,35 @@
+# A simple Rng - for now use a shift generator see https://en.wikipedia.org/wiki/Xorshift
+
+# The standard mojo random calls are system wide and lock if called rapidly from multiple threads
+# This is designed to genrate float32 or float64 random numbers between 0 and 1 with an internal seed state.
+
+struct Rng:
+    var _internal : UInt64
+
+    fn __init__(inout self, seed : UInt64 = 1):
+        self._internal = seed
+        # The period is 2^64 -1 however it has a fixed point at 0! - which internal cant be set to
+        if self._internal == 0:
+             self._internal = 1
+        self._step()
+
+    fn _step(inout self):
+        var state : UInt64 = self._internal
+        state ^= state << 13
+        state ^= state >> 7
+        state ^= state << 17
+        self._internal = state
+
+    fn float32(inout self) -> Float32:
+        self._step()
+        var denom : UInt64 = (1 << 23)
+        var bits : UInt64 = self._internal & (denom - 1)
+        return bits.cast[DType.float32]() / denom.cast[DType.float32]()
+
+    fn float64(inout self) -> Float64:
+        self._step()
+        var denom : UInt64 = (1 << 52)
+        var bits : UInt64 = self._internal & (denom - 1)
+        return bits.cast[DType.float64]() / denom.cast[DType.float64]()
+
+

--- a/src/mo3d/sample/basic_three_sphere_scene.mojo
+++ b/src/mo3d/sample/basic_three_sphere_scene.mojo
@@ -1,5 +1,3 @@
-from random import random_float64
-
 from mo3d.ecs.component_store import ComponentStore
 from mo3d.math.vec import Vec
 from mo3d.math.point import Point

--- a/src/mo3d/sample/sphere_scene.mojo
+++ b/src/mo3d/sample/sphere_scene.mojo
@@ -1,5 +1,3 @@
-from random import random_float64
-
 from memory.arc import ArcPointer
 
 from mo3d.ecs.component_store import ComponentStore
@@ -25,10 +23,8 @@ fn sphere_scene_3d[T: DType](inout store: ComponentStore[T, 3], grid_size: Int =
     """
     alias dim = 3
 
-    fn random_float(min: Scalar[T] = 0, max: Scalar[T] = 1.0) -> Scalar[T]:
-        return random_float64(
-            min.cast[DType.float64](), max.cast[DType.float64]()
-        ).cast[T]()
+    fn random_float(mut rng : Rng, min: Scalar[T] = 0, max: Scalar[T] = 1.0) -> Scalar[T]:
+        return min + (rng.float64().cast[T]() * (max - min))
 
     # Ground
     var tex_ground_light = Texture[T, dim](
@@ -57,9 +53,9 @@ fn sphere_scene_3d[T: DType](inout store: ComponentStore[T, 3], grid_size: Int =
     # Random spheres
     for a in range(-grid_size, grid_size):
         for b in range(-grid_size, grid_size):
-            var choose_mat = random_float()
+            var choose_mat = random_float(rng)
             var center = Point[T, dim](
-                a + 0.9 * random_float(), 0.2, b + 0.9 * random_float()
+                a + 0.9 * random_float(rng), 0.2, b + 0.9 * random_float(rng)
             )
 
             if (center - Point[T, dim](4, 0.2, 0)).length() > 0.9:
@@ -85,7 +81,7 @@ fn sphere_scene_3d[T: DType](inout store: ComponentStore[T, 3], grid_size: Int =
                 elif choose_mat < 0.8:
                     # metal
                     var albedo = Color4[T].random(rng, 0.5, 1)
-                    var fuzz = random_float(0, 0.5)
+                    var fuzz = random_float(rng, 0, 0.5)
                     sphere_material = Material[T, dim](
                         Metal[T, dim](albedo, fuzz)
                     )

--- a/src/mo3d/sample/sphere_scene.mojo
+++ b/src/mo3d/sample/sphere_scene.mojo
@@ -17,6 +17,8 @@ from mo3d.texture.texture import Texture
 from mo3d.texture.solid import Solid
 from mo3d.texture.checker import Checker
 
+from mo3d.random.rng import Rng
+
 fn sphere_scene_3d[T: DType](inout store: ComponentStore[T, 3], grid_size: Int = 11) raises:
     """
     The classic end scene from the Ray Tracing in One Weekend by Peter Shirley.
@@ -50,6 +52,8 @@ fn sphere_scene_3d[T: DType](inout store: ComponentStore[T, 3], grid_size: Int =
         mat_ground,
     )
 
+    var rng = Rng(12345)
+
     # Random spheres
     for a in range(-grid_size, grid_size):
         for b in range(-grid_size, grid_size):
@@ -63,7 +67,7 @@ fn sphere_scene_3d[T: DType](inout store: ComponentStore[T, 3], grid_size: Int =
 
                 if choose_mat < 0.7:
                     # diffuse
-                    var albedo_colour = Color4[T].random() * Color4[T].random()
+                    var albedo_colour = Color4[T].random(rng) * Color4[T].random(rng)
                     var albedo = Texture[T, dim](
                         Solid[T, dim](albedo_colour)
                     )
@@ -80,7 +84,7 @@ fn sphere_scene_3d[T: DType](inout store: ComponentStore[T, 3], grid_size: Int =
                     )
                 elif choose_mat < 0.8:
                     # metal
-                    var albedo = Color4[T].random(0.5, 1)
+                    var albedo = Color4[T].random(rng, 0.5, 1)
                     var fuzz = random_float(0, 0.5)
                     sphere_material = Material[T, dim](
                         Metal[T, dim](albedo, fuzz)

--- a/test/mo3d/test_material.mojo
+++ b/test/mo3d/test_material.mojo
@@ -10,6 +10,8 @@ from mo3d.material.lambertian import Lambertian
 from mo3d.texture.texture import Texture
 from mo3d.texture.solid import Solid
 
+from mo3d.random.rng import Rng
+
 alias f32 = DType.float32
 
 fn test_create_lambertian_material() raises:
@@ -51,8 +53,10 @@ fn test_lambertian_material_scatter_ray() raises:
     var r_scattered = Ray[DType.float32, 3]()
     var attenuation = Color4[DType.float32]()
 
+    var rng = Rng(1)
+
     var scattered = m.scatter(
-        r, hr, attenuation, r_scattered
+        rng, r, hr, attenuation, r_scattered
     )
 
     assert_true(scattered)


### PR DESCRIPTION
After implementing https://github.com/thomas-gale/mo3d/pull/15 I again ran perf and found a chunk of time was spend in the call the the platform random function.

I believe this is because the platform random method:
1. Shares state so thread need to get a mutex to call it causing parallization issues.
2. This can need a syscall to refill random from the kernel

I made a simple random number generator that will be created and seeded per pixel and doesnt share state with any of the others. This uses a simple but effective xor shift to generate the data which is sufficent for our purposes - they will be converted into floats not for hashing.

We then pass these down to the various methods that need random numbers.

Before the compute time on my PC was 214 ms after it was 59 ms on average.