### PR TITLE
Add basic physics engine

### DIFF
--- a/src/main.mojo
+++ b/src/main.mojo
@@ -25,6 +25,7 @@ from mo3d.geometry.geometry import Geometry
 from mo3d.geometry.sphere import Sphere
 from mo3d.camera.camera import Camera
 from mo3d.window.sdl2_window import SDL2Window
+from mo3d.phys.world import run_physics_store
 
 from mo3d.ecs.component_store import ComponentStore
 from mo3d.scene.construct_bvh import construct_bvh_store
@@ -89,6 +90,13 @@ fn main() raises:
     var window = SDL2Window.create("mo3d", width, height)
 
     while window.process_events(camera):
+        if camera._simulate_physics:
+            print("Running physics")
+            run_physics_store(store, 0.25)
+            bvh_root = construct_bvh_store(store)
+            camera.reset_samples()
+            camera._simulate_physics = False
+
         start_time = perf_counter()
         camera.render(
             bvh_root,

--- a/src/mo3d/camera/camera.mojo
+++ b/src/mo3d/camera/camera.mojo
@@ -73,6 +73,8 @@ struct Camera[
     var _last_x: Int32  # Last x position of the mouse
     var _last_y: Int32  # Last y position of the mouse
 
+    var _simulate_physics : Bool # Should we run a physics sim - ideally shouldnt be recorded on camera
+
     fn __init__(
         inout self,
     ) raises:
@@ -136,6 +138,7 @@ struct Camera[
         self._dragging = False
         self._last_x = 0
         self._last_y = 0
+        self._simulate_physics = False
 
         # Do a final update of the view matrix: TODO: Remove the duplicate code above.
         self.update_view_matrix()
@@ -169,6 +172,12 @@ struct Camera[
             self._pixel_delta_u + self._pixel_delta_v
         )
 
+    fn reset_samples(mut self):
+        self._sensor_samples = 0  # Reset samples (so that sensor doesn't accumulate a blend of old/new positions)
+        for i in range(height * width * channels):
+            (self._sensor_accum + i)[] = 0.0
+            (self._sensor_state + i)[] = 1.0
+
     fn arcball(inout self, x: Int32, y: Int32) raises -> None:
         """
         Rotate the camera around the center of the scene.
@@ -177,9 +186,7 @@ struct Camera[
         if not self._dragging:
             return
 
-        self._sensor_samples = 0  # Reset samples (so that sensor doesn't accumulate a blend of old/new positions)
-        for i in range(height * width * channels):
-            (self._sensor_accum + i)[] = 0.0
+        self.reset_samples()
 
         # Get the homogenous position of the camera and pivot point
         var position = Vec[T, dim](

--- a/src/mo3d/ecs/component.mojo
+++ b/src/mo3d/ecs/component.mojo
@@ -4,6 +4,7 @@ from mo3d.math.point import Point
 from mo3d.material.material import Material
 from mo3d.geometry.geometry import Geometry
 from mo3d.geometry.aabb import AABB
+from mo3d.phys.data import PhysData
 
 from mo3d.ecs.entity import EntityID
 
@@ -20,6 +21,8 @@ alias MaterialComponent = Material
 
 alias BoundingBoxComponent = AABB
 
+alias PhysicsComponent = PhysData
+
 alias ComponentID = Int
 
 alias ComponentTypeID = Int
@@ -32,3 +35,4 @@ struct ComponentType:
     alias Geometry: ComponentTypeID = 1 << 3
     alias Material: ComponentTypeID = 1 << 4
     alias BoundingBox: ComponentTypeID = 1 << 5
+    alias PhysicsComponent : ComponentTypeID = 1 << 6

--- a/src/mo3d/ecs/component_store.mojo
+++ b/src/mo3d/ecs/component_store.mojo
@@ -15,7 +15,8 @@ from mo3d.ecs.component import (
     OrientationComponent,
     GeometryComponent,
     MaterialComponent,
-    BoundingBoxComponent
+    BoundingBoxComponent,
+    PhysicsComponent
 )
 
 from python import Python
@@ -38,7 +39,8 @@ struct ComponentStore[T: DType, dim: Int]:
         OrientationComponent[T, dim],
         GeometryComponent[T, dim],
         MaterialComponent[T, dim],
-        BoundingBoxComponent[T, dim]
+        BoundingBoxComponent[T, dim],
+        PhysicsComponent[T]
     ]
 
     var position_components: List[PositionComponent[T, dim]]
@@ -58,6 +60,9 @@ struct ComponentStore[T: DType, dim: Int]:
 
     var bounding_box_components: List[BoundingBoxComponent[T, dim]]
     var bounding_box_component_to_entities: Dict[ComponentID, EntityID]
+
+    var physics_components: List[PhysicsComponent[T]]
+    var physics_component_to_entities: Dict[ComponentID, EntityID]
 
     var entity_to_components: Dict[EntityID, Dict[ComponentTypeID, ComponentID]]
     var entity_to_component_type_mask: Dict[EntityID, ComponentTypeID]
@@ -80,6 +85,9 @@ struct ComponentStore[T: DType, dim: Int]:
 
         self.bounding_box_components = List[BoundingBoxComponent[T, dim]]()
         self.bounding_box_component_to_entities = Dict[ComponentID, EntityID]()
+
+        self.physics_components = List[PhysicsComponent[T]]()
+        self.physics_component_to_entities = Dict[ComponentID, EntityID]()
 
         self.entity_to_components = Dict[
             EntityID, Dict[ComponentTypeID, ComponentID]
@@ -207,6 +215,28 @@ struct ComponentStore[T: DType, dim: Int]:
 
         return component_id
 
+    fn _add_physics_component(
+        inout self, entity_id: EntityID, component: PhysicsComponent[T]
+    ) raises -> ComponentID:
+        if (
+            self.entity_to_component_type_mask[entity_id]
+            & ComponentType.PhysicsComponent
+        ):
+            raise Error("Entity already has a physics component")
+
+        self.physics_components.append(component)
+        var component_id = ComponentID(len(self.physics_components) - 1)
+        self.physics_component_to_entities[component_id] = entity_id
+
+        self.entity_to_components[entity_id][
+            ComponentType.PhysicsComponent
+        ] = component_id
+        self.entity_to_component_type_mask[
+            entity_id
+        ] |= ComponentType.PhysicsComponent
+
+        return component_id
+
     fn create_entity(inout self) -> EntityID:
         """
         This implementation is not thread safe.
@@ -251,6 +281,10 @@ struct ComponentStore[T: DType, dim: Int]:
         elif component.isa[OrientationComponent[T, dim]]():
             return self._add_orientation_component(
                 entity_id, component[OrientationComponent[T, dim]]
+            )
+        elif component.isa[PhysicsComponent[T]]():
+            return self._add_physics_component(
+                entity_id, component[PhysicsComponent[T]]
             )
         else:
             raise Error("Unknown component type")

--- a/src/mo3d/phys/data.mojo
+++ b/src/mo3d/phys/data.mojo
@@ -1,0 +1,8 @@
+from mo3d.phys.geometry import PhysGeom
+
+# The data on a component needed to simulate it in phycis
+@value
+struct PhysData[T : DType]:
+    var _geom : PhysGeom[T]
+    var _mobile : Bool
+

--- a/src/mo3d/phys/entity.mojo
+++ b/src/mo3d/phys/entity.mojo
@@ -15,26 +15,27 @@ from memory import UnsafePointer
 @value 
 struct CollisionRecord[T : DType]:
     alias FloatType = T # Needed to get around some isues with trait param
-    var a_ptr : UnsafePointer[Entity[T]]
-    var b_ptr : UnsafePointer[Entity[T]]
+    var a_ptr : UnsafePointer[PhysEntity[T]]
+    var b_ptr : UnsafePointer[PhysEntity[T]]
     var pt_a_in_b : Vec[T, 3]  
     var pt_b_in_a : Vec[T, 3]
 
 @value
-struct Entity[T: DType]:
+struct PhysEntity[T: DType]:
+    var _id : Int
     var _geom : PhysGeom[T]
     var _pos : Point[T, 3]
     var _vel : Vec[T, 3]
     var _force : Vec[T, 3]
     var mobile : Bool
 
-    fn apply_force(inout self, force : Vec[T, 3]):
+    fn apply_force(mut self, force : Vec[T, 3]):
         self._force += force
 
-    fn move_by(inout self, dir : Vec[T, 3]):
+    fn move_by(mut self, dir : Vec[T, 3]):
         self._pos += dir
 
-    fn move(inout self, step : Scalar[T]):
+    fn move(mut self, step : Scalar[T]):
         if not self.mobile:
             return
         self._vel += self._force / self.mass() * step
@@ -44,5 +45,5 @@ struct Entity[T: DType]:
     fn mass(self) -> Scalar[T]:
         return self._geom.volume()
 
-fn collision[T : DType](entity_a : Entity[T], entity_b : Entity[T]) -> Optional[CollisionRecord[T]]:
+fn collision[T : DType](entity_a : PhysEntity[T], entity_b : PhysEntity[T]) -> Optional[CollisionRecord[T]]:
     return Optional[CollisionRecord[T]]()

--- a/src/mo3d/phys/entity.mojo
+++ b/src/mo3d/phys/entity.mojo
@@ -1,0 +1,44 @@
+# Initial outline in https://winter.dev/articles/physics-engine
+
+from mo3d.math.vec import Vec
+from mo3d.math.point import Point
+from mo3d.math.mat import RotMat, Mat
+
+from mo3d.phys.geometry import PhysGeom
+
+from collections import Optional
+from memory import UnsafePointer
+
+
+
+
+@value 
+struct CollisionRecord[T : DType]:
+    var a_ptr : UnsafePointer[Entity[T]]
+    var b_ptr : UnsafePointer[Entity[T]]
+    var pt_a_in_b : Vec[T, 3]  
+    var pt_b_in_a : Vec[T, 3]
+
+@value
+struct Entity[T: DType]:
+    var _geom : PhysGeom[T]
+    var _pos : Point[T, 3]
+    var _vel : Vec[T, 3]
+    var _force : Vec[T, 3]
+    var mobile : Bool
+
+    fn apply_force(inout self, force : Vec[T, 3]):
+        self._force += force
+
+    fn move_by(inout self, dir : Vec[T, 3]):
+        self._pos += dir
+
+    fn move(inout self, step : Scalar[T]):
+        if not self.mobile:
+            return
+        self._vel += self._force / self._geom.mass() * step
+        self._pos += self._vel * step
+        self._force += Vec[T, 3](0,0,0)
+
+fn collision[T : DType](entity_a : Entity[T], entity_b : Entity[T]) -> Optional[CollisionRecord[T]]:
+    return Optional[CollisionRecord[T]]()

--- a/src/mo3d/phys/entity.mojo
+++ b/src/mo3d/phys/entity.mojo
@@ -14,6 +14,7 @@ from memory import UnsafePointer
 
 @value 
 struct CollisionRecord[T : DType]:
+    alias FloatType = T # Needed to get around some isues with trait param
     var a_ptr : UnsafePointer[Entity[T]]
     var b_ptr : UnsafePointer[Entity[T]]
     var pt_a_in_b : Vec[T, 3]  
@@ -36,9 +37,12 @@ struct Entity[T: DType]:
     fn move(inout self, step : Scalar[T]):
         if not self.mobile:
             return
-        self._vel += self._force / self._geom.mass() * step
+        self._vel += self._force / self.mass() * step
         self._pos += self._vel * step
         self._force += Vec[T, 3](0,0,0)
+
+    fn mass(self) -> Scalar[T]:
+        return self._geom.volume()
 
 fn collision[T : DType](entity_a : Entity[T], entity_b : Entity[T]) -> Optional[CollisionRecord[T]]:
     return Optional[CollisionRecord[T]]()

--- a/src/mo3d/phys/geometry.mojo
+++ b/src/mo3d/phys/geometry.mojo
@@ -1,0 +1,38 @@
+from utils import Variant
+
+@value
+struct PhysPlane[T : DType]:
+
+    fn mass(self) -> Scalar[T]:
+        return 0
+
+@value
+struct PhysSphere[T : DType]:
+    var radius : Scalar[T]
+
+    fn mass(self) -> Scalar[T]:
+        return self.radius * self.radius * self.radius
+
+
+@value
+struct PhysGeom[T : DType]:
+    alias Variant = Variant[PhysPlane[T], PhysSphere[T]]
+    var _geom: Self.Variant
+
+    fn __init__(inout self, geom : Self.Variant) raises:
+        if geom.isa[PhysSphere[T]]():
+            self._geom = geom
+        elif geom.isa[PhysPlane[T]]():
+            self._geom = geom
+        else:
+            raise Error("Geometry c'tor: Unsupported geometry type")
+
+    fn mass(self) -> Scalar[T]:
+        if self._geom.isa[PhysSphere[T]]():
+            return self._geom[PhysSphere[T]].mass()
+        elif self._geom.isa[PhysPlane[T]]():
+            return self._geom[PhysPlane[T]].mass()
+        else:
+            return 0
+
+    

--- a/src/mo3d/phys/geometry.mojo
+++ b/src/mo3d/phys/geometry.mojo
@@ -3,14 +3,14 @@ from utils import Variant
 @value
 struct PhysPlane[T : DType]:
 
-    fn mass(self) -> Scalar[T]:
+    fn volume(self) -> Scalar[T]:
         return 0
 
 @value
 struct PhysSphere[T : DType]:
     var radius : Scalar[T]
 
-    fn mass(self) -> Scalar[T]:
+    fn volume(self) -> Scalar[T]:
         return self.radius * self.radius * self.radius
 
 
@@ -27,11 +27,11 @@ struct PhysGeom[T : DType]:
         else:
             raise Error("Geometry c'tor: Unsupported geometry type")
 
-    fn mass(self) -> Scalar[T]:
+    fn volume(self) -> Scalar[T]:
         if self._geom.isa[PhysSphere[T]]():
-            return self._geom[PhysSphere[T]].mass()
+            return self._geom[PhysSphere[T]].volume()
         elif self._geom.isa[PhysPlane[T]]():
-            return self._geom[PhysPlane[T]].mass()
+            return self._geom[PhysPlane[T]].volume()
         else:
             return 0
 

--- a/src/mo3d/phys/geometry.mojo
+++ b/src/mo3d/phys/geometry.mojo
@@ -1,10 +1,18 @@
+from mo3d.math.vec import Vec
+from mo3d.math.point import Point
+
+from collections import Optional
 from utils import Variant
 
 @value
-struct PhysPlane[T : DType]:
+struct GeomColRecord[T : DType]:
+    var pt_a_in_b : Vec[T, 3]  
+    var pt_b_in_a : Vec[T, 3]
 
-    fn volume(self) -> Scalar[T]:
-        return 0
+    fn shift(mut self, delta : Vec[T, 3]):
+        self.pt_a_in_b += delta
+        self.pt_b_in_a += delta
+
 
 @value
 struct PhysSphere[T : DType]:
@@ -13,16 +21,24 @@ struct PhysSphere[T : DType]:
     fn volume(self) -> Scalar[T]:
         return self.radius * self.radius * self.radius
 
+    fn collide_sphere(self, other : PhysSphere[T], rel_p : Point[T, 3]) -> Optional[GeomColRecord[T]]:
+        var len = rel_p.length()
+        if len > self.radius + other.radius:
+            return Optional[GeomColRecord[T]]()
+        return GeomColRecord[T](
+            (rel_p / len) * self.radius,
+            (rel_p / len) * (len - other.radius),
+        )
+
+
 
 @value
 struct PhysGeom[T : DType]:
-    alias Variant = Variant[PhysPlane[T], PhysSphere[T]]
+    alias Variant = Variant[PhysSphere[T]]
     var _geom: Self.Variant
 
-    fn __init__(inout self, geom : Self.Variant) raises:
+    fn __init__(mut self, geom : Self.Variant) raises:
         if geom.isa[PhysSphere[T]]():
-            self._geom = geom
-        elif geom.isa[PhysPlane[T]]():
             self._geom = geom
         else:
             raise Error("Geometry c'tor: Unsupported geometry type")
@@ -30,9 +46,22 @@ struct PhysGeom[T : DType]:
     fn volume(self) -> Scalar[T]:
         if self._geom.isa[PhysSphere[T]]():
             return self._geom[PhysSphere[T]].volume()
-        elif self._geom.isa[PhysPlane[T]]():
-            return self._geom[PhysPlane[T]].volume()
         else:
             return 0
+
+fn collision_geometry[T: DType](
+    a : PhysGeom[T], 
+    b : PhysGeom[T],
+    a_p : Point[T, 3],
+    b_p : Point[T, 3]
+) -> Optional[GeomColRecord[T]]:
+    if a._geom.isa[PhysSphere[T]]() and b._geom.isa[PhysSphere[T]]():
+        var ba = b_p - a_p
+        var col_record = a._geom[PhysSphere[T]].collide_sphere(b._geom[PhysSphere[T]], ba)
+        if col_record:
+            col_record.value().shift(-ba)
+        return col_record
+    else:
+        return Optional[GeomColRecord[T]]()
 
     

--- a/src/mo3d/phys/solver.mojo
+++ b/src/mo3d/phys/solver.mojo
@@ -10,4 +10,23 @@ trait PhysSolver(CollectionElement):
 @value
 struct PositionSolver(PhysSolver):
     fn solve(self, collision_record : CollisionRecord):
-        pass
+        alias T = collision_record.FloatType
+        var diff = collision_record.pt_a_in_b - collision_record.pt_b_in_a
+        if diff.length_squared() < 1e-4:
+            return
+        var a = collision_record.a_ptr[]
+        var b = collision_record.b_ptr[]
+
+        diff *= 0.8
+
+        if a.mobile and b.mobile:
+            var a_inv_mass = 1.0 / a.mass()
+            var b_inv_mass = 1.0 / b.mass()
+            diff /= (a_inv_mass + b_inv_mass)
+            a.move_by(-diff * a_inv_mass)
+            b.move_by(diff * b_inv_mass)
+        elif a.mobile:
+            a.move_by(-diff)
+        elif b.mobile:
+            b.move_by(diff)
+

--- a/src/mo3d/phys/solver.mojo
+++ b/src/mo3d/phys/solver.mojo
@@ -1,0 +1,13 @@
+from mo3d.phys.entity import CollisionRecord
+
+
+
+# Need to specify as cant make trait generic over DType
+trait PhysSolver(CollectionElement):
+    fn solve(self, collision_record : CollisionRecord):
+        ...
+
+@value
+struct PositionSolver(PhysSolver):
+    fn solve(self, collision_record : CollisionRecord):
+        pass

--- a/src/mo3d/phys/world.mojo
+++ b/src/mo3d/phys/world.mojo
@@ -1,32 +1,32 @@
-from mo3d.phys.entity import Entity, CollisionRecord, collision
+from mo3d.phys.entity import PhysEntity, CollisionRecord, collision
 from mo3d.phys.solver import PhysSolver, PositionSolver
 
 from mo3d.math.vec import Vec
 
-@value 
+from mo3d.ecs.component_store import ComponentStore, ComponentType
+
+@value
 struct World[T: DType, Solver : PhysSolver]:
-    var _elements : List[Entity[T]]
+    var _elements : List[PhysEntity[T]]
     var _max_tick_length : Scalar[T]
     var _gravity : Vec[T, 3]
     var _solver : Solver
 
-    fn __init__(inout self, solver : Solver):
-        self._elements = List[Entity[T]]()
+    fn __init__(mut self, solver : Solver):
+        self._elements = List[PhysEntity[T]]()
         self._max_tick_length = 0.01
         self._gravity = Vec[T, 3](0,0,-9.81)
         self._solver = solver
 
-    fn simluate(inout self, time : Scalar[T]): 
+    fn simluate(mut self, time : Scalar[T]): 
         var curr_time : Scalar[T] = 0
         while curr_time < (time - self._max_tick_length):
             self.tick(self._max_tick_length)
         var rem = time - curr_time
         if rem > 1e-6:
             self.tick(rem)
-
     
-    
-    fn tick(inout self, step : Scalar[T]):
+    fn tick(mut self, step : Scalar[T]):
         var collisions = List[CollisionRecord[T]]()
         for i in range(len(self._elements)):
             for j in range(i, len(self._elements)):
@@ -40,9 +40,43 @@ struct World[T: DType, Solver : PhysSolver]:
         for elem in self._elements:
             elem[].apply_force(self._gravity)
             elem[].move(step)
-        
 
+# This currently blocks but could run async
+fn run_physics_store[
+    T: DType, dim: Int
+](mut store: ComponentStore[T, dim], time : Scalar[T]) raises:
+    # We can only do physics on a 3D store
+    @parameter
+    if dim != 3:
+        return
+    var store3 = rebind[ComponentStore[T, 3]](store)
+    var solver = PositionSolver()
+    var world = World[T](solver)
+    for entity_id in store3.get_entities_with_components(ComponentType.Position):
+        var phys = store3.physics_components[
+            store3.entity_to_components[entity_id[]][ComponentType.PhysicsComponent]
+        ]
+        var pos = store3.position_components[
+            store3.entity_to_components[entity_id[]][ComponentType.Position]
+        ]
+        var phys_entity = PhysEntity[T](
+            entity_id[],
+            phys._geom,
+            pos,
+            Vec[T, 3](0,0,0),
+            Vec[T, 3](0,0,0),
+            phys._mobile
+        )
+        world._elements.append(phys_entity)
 
+    print("Setup")
+    #world.simluate(time)
+
+    # Update store
+    for elem in world._elements:
+        store3.position_components[
+            store3.entity_to_components[elem[]._id][ComponentType.Position]
+        ] = elem[]._pos
     
         
 

--- a/src/mo3d/phys/world.mojo
+++ b/src/mo3d/phys/world.mojo
@@ -1,0 +1,48 @@
+from mo3d.phys.entity import Entity, CollisionRecord, collision
+from mo3d.phys.solver import PhysSolver, PositionSolver
+
+from mo3d.math.vec import Vec
+
+@value 
+struct World[T: DType, Solver : PhysSolver]:
+    var _elements : List[Entity[T]]
+    var _max_tick_length : Scalar[T]
+    var _gravity : Vec[T, 3]
+    var _solver : Solver
+
+    fn __init__(inout self, solver : Solver):
+        self._elements = List[Entity[T]]()
+        self._max_tick_length = 0.01
+        self._gravity = Vec[T, 3](0,0,-9.81)
+        self._solver = solver
+
+    fn simluate(inout self, time : Scalar[T]): 
+        var curr_time : Scalar[T] = 0
+        while curr_time < (time - self._max_tick_length):
+            self.tick(self._max_tick_length)
+        var rem = time - curr_time
+        if rem > 1e-6:
+            self.tick(rem)
+
+    
+    
+    fn tick(inout self, step : Scalar[T]):
+        var collisions = List[CollisionRecord[T]]()
+        for i in range(len(self._elements)):
+            for j in range(i, len(self._elements)):
+                var col = collision(self._elements[i], self._elements[j])
+                if col:
+                    collisions.append(col.value())
+
+        for col in collisions:
+            self._solver.solve(col[])
+
+        for elem in self._elements:
+            elem[].apply_force(self._gravity)
+            elem[].move(step)
+        
+
+
+    
+        
+

--- a/src/mo3d/sample/sample_scene.mojo
+++ b/src/mo3d/sample/sample_scene.mojo
@@ -1,7 +1,7 @@
 from memory.arc import ArcPointer
 from collections import Optional
 
-from mo3d.ecs.component_store import ComponentStore
+from mo3d.ecs.component_store import ComponentStore, ComponentType
 from mo3d.math.vec import Vec
 from mo3d.math.mat import RotMat
 from mo3d.math.point import Point
@@ -17,6 +17,8 @@ from mo3d.material.diffuse_light import DiffuseLight
 from mo3d.texture.texture import Texture
 from mo3d.texture.solid import Solid
 from mo3d.texture.checker import Checker
+from mo3d.phys.geometry import PhysGeom, PhysSphere
+from mo3d.phys.data import PhysData
 
 from mo3d.random.rng import Rng
 
@@ -44,11 +46,13 @@ fn sample_scene_3d[T: DType](inout store: ComponentStore[T, 3], grid_size: Int =
     )
     var ground = Sphere[T, dim](1_000)
     var ground_entity_id = store.create_entity()
+    # Add physics for fixed ground plane
     _ = store.add_components(
         ground_entity_id,
         Point[T, dim](0, -1_000, 0),
         Geometry[T, dim](ground),
         mat_ground,
+        PhysData[T](PhysGeom[T](PhysSphere[T](ground._radius)), False)
     )
 
     var rng = Rng(12345)
@@ -127,3 +131,16 @@ fn sample_scene_3d[T: DType](inout store: ComponentStore[T, 3], grid_size: Int =
     var sphere3 = Sphere[T, dim](1.0)
     var sphere3_entity_id = store.create_entity()
     _ = store.add_components(sphere3_entity_id, Point[T, dim](4, 1, 0), Geometry[T, dim](sphere3), mat3)
+
+    # Add physics objects for all the mobile bits
+    for entity_id in store.get_entities_with_components(ComponentType.Geometry):
+        var geom = store.geometry_components[
+            store.entity_to_components[entity_id[]][ComponentType.Geometry]
+        ]
+        # Add to all spheres is we havent set up a special component
+        if geom._hittable.isa[Sphere[T, dim]]() and not store.entity_has_components(entity_id[], ComponentType.PhysicsComponent):
+            var rad = geom._hittable[Sphere[T, dim]]._radius
+            _ = store.add_component(
+                entity_id[], 
+                PhysData[T](PhysGeom[T](PhysSphere[T](rad)), True)
+            )

--- a/src/mo3d/window/sdl2_window.mojo
+++ b/src/mo3d/window/sdl2_window.mojo
@@ -16,6 +16,7 @@ from mo3d.window.sdl2 import (
     SDL_TEXTUREACCESS_STREAMING,
     SDL_WINDOWPOS_CENTERED,
     SDL_WINDOW_SHOWN,
+    SDL_KEYDOWN,
     SDL,
     SDL_Rect,
     SDL_Renderer,
@@ -114,9 +115,12 @@ struct SDL2Window(Window):
                 if self._event.type == SDL_MOUSEMOTION:
                     var motion = self._event.as_mousemotion()
                     camera.arcball(motion[].x, motion[].y)
+                if self._event.type == SDL_KEYDOWN:
+                    var button = self._event.as_keyboard()
+                    if button[].keysym.keycode == 112:
+                        camera._simulate_physics = True
             except Error:
                 print("Failed to cast event")
-
         return True
 
     fn redraw[


### PR DESCRIPTION
Add a basic physics engine (that for now does a minor positional update) and only works on spheres.

This is:
1. Unoptimized
2. Only works on spheres
3. Doesn't deal with rotation of objects
4. Has a very naive solver

I have added a invoker 'p' which will simulate 0.25s of movement clear the render and start rendering again - mostly for testing.